### PR TITLE
Force slash path internally to fix behavior on Windows

### DIFF
--- a/autoload/fern_git_status.vim
+++ b/autoload/fern_git_status.vim
@@ -49,6 +49,7 @@ function! s:on_redraw(helper) abort
         \ 'stained_patterns': g:fern_git_status#stained_patterns,
         \}
   call fern_git_status#investigator#investigate(a:helper, options)
+        \.then({ m -> fern#logger#tap(m) })
         \.then({ m -> map(a:helper.fern.visible_nodes, { -> s:update_node(m, v:val) }) })
         \.then({ -> s:redraw(a:helper) })
         \.catch({ e -> s:handle_error(e) })

--- a/autoload/fern_git_status.vim
+++ b/autoload/fern_git_status.vim
@@ -55,7 +55,8 @@ function! s:on_redraw(helper) abort
 endfunction
 
 function! s:update_node(status_map, node) abort
-  let status = get(a:status_map, a:node._path, '')
+  let path = fern#internal#filepath#to_slash(a:node._path)
+  let status = get(a:status_map, path, '')
   let a:node.badge = status ==# '' ? '' : printf(' [%s]', status)
   return a:node
 endfunction

--- a/autoload/fern_git_status/process.vim
+++ b/autoload/fern_git_status/process.vim
@@ -70,7 +70,7 @@ endfunction
 " Git for Windows return slash separated path but the path is
 " not compatible with fern's slash separated path so normalization
 " is required
-if has("win32")
+if has('win32')
   function! s:normalize_path(path) abort
     let filepath = fern#internal#filepath#from_slash(a:path)
     return fern#internal#filepath#to_slash(filepath)


### PR DESCRIPTION
Close #10 

![Windows 10 2021-01-31 14-18-05](https://user-images.githubusercontent.com/546312/106375431-46ac2900-63cf-11eb-9b1a-8432366c91ad.png)

Note that https://github.com/lambdalisue/fern.vim/releases/tag/v1.31.0 or later is required